### PR TITLE
Openocd config file added to flash and debug with ftdi interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ build/*
 #clion
 .idea/*
 cmake-build-debug/
+cmake-build-target/
 /build-esp32/
 /build-local/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,11 @@ target_link_libraries(${elf_file} ${ALIAS_PREFIX}::esp32 ${ALIAS_PREFIX}::freert
 if(COMPILE_ESP)
     # Register the executable for idf, needs to be done after linking
     idf_build_executable(${elf_file})
+    # Create target to flash via openocd with JTAG interface
+    add_custom_target(
+            openocd-flash
+            COMMAND openocd -f ${CMAKE_CURRENT_SOURCE_DIR}/tools/openocd/adafruit-esp.cfg -c "program_esp ${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}.bin 0x10000 verify exit"
+    )
 else()
     add_custom_target(
             run

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The esp32 target could be changed in the future to use openocd.
 
 The project includes a target called ``openocd-flash`` that will flash the program over JTAG with the adafruit ftd2232h breakout board. For other adapters, other .cfg might need to be supplied. Debugging is supported in VS Code. Here is the launch and task files necessary. Some changes to properly resolve paths are needed:
 launch.json
-````
+````json
     {
     // Use IntelliSense to learn about possible attributes.
     // Hover to view descriptions of existing attributes.
@@ -112,7 +112,7 @@ launch.json
 }
 ````
 tasks.json
-````
+````json
     {
     "version": "2.0.0",
     "tasks": [
@@ -148,6 +148,18 @@ tasks.json
 ````
 
 IMPORTANT: For some reason, VS Code has trouble attaching the debugger on the first launch. If this occurs, relaunch the configuration and the program should launch and break on app_main() entry.
+
+## Connections to ftd2232h breakout board
+
+````
+Connections:
+FTD2232H        ESP32       Signal
+D0              D13         TCLK
+D1              D12         TDI
+D2              D15         TMS
+D3              D14         TDO
+GND             GND         GND
+````
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ tasks.json
             "label": "openocd",
             "type": "shell",
             "isBackground": true,
+            "dependsOn": "update-build",
             "problemMatcher": [
                 {
                   "pattern": [
@@ -157,6 +158,16 @@ tasks.json
                 "cwd": "/home/casto/.espressif/tools/openocd-esp32/v0.10.0-esp32-20191114/openocd-esp32" // to be changed by user
             },
             "command": "bin/openocd -s share/openocd/scripts -f ${workspaceFolder}/tools/openocd/adafruit-esp.cfg -c 'program_esp ${workspaceFolder}/cmake-build-target/esp32-boilerplate.bin 0x10000'",
+        },
+        ,
+        {
+          "label": "update-build",
+          "type": "shell",
+          "isBackground": false,
+          "options": {
+            "cwd": "${workspaceFolder}/cmake-build-target/" // to be changed by user if different build directory
+          },
+          "command": "make app"
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -74,7 +74,19 @@ This has been tested on Ubuntu 20.04 but the same logic should apply to any syst
 As can be seen in the scripts, the target can be run locally with a make run command and on the esp32 using the idf.py python script to flash and open a serial on the esp32.
 The esp32 target could be changed in the future to use openocd.
 
-The project includes a target called ``openocd-flash`` that will flash the program over JTAG with the adafruit ftd2232h breakout board. For other adapters, other .cfg might need to be supplied. Debugging is supported in VS Code. Here is the launch and task files necessary. Some changes to properly resolve paths are needed:
+The project includes a target called ``openocd-flash`` that will flash the program over JTAG with the adafruit ftd2232h breakout board. For other adapters, other .cfg might need to be supplied. 
+
+#### Debugging
+To debug using CLion, you can create a run configuration using the Embedded Gdb Server template. Follow these steps to create this configuration:
+1. Create a new configuration using Embedded GDB Server Template
+2. Set the executable to the .elf file of the project
+3. Select the xtensa gdb located under .espressif (exemple path: ```/home/casto/.espressif/tools/xtensa-esp32-elf/esp-2020r2-8.2.0/xtensa-esp32-elf/bin/xtensa-esp32-elf-gdb```)
+4. For download executable, select ``None``. This will be done manually while launching the gdb server (aka openocd)
+5. For target remote args, enter ``localhost 3333``
+6. For the GDB server, choose the one provided with the esp tool chain, similarly to the gdb (example path: ``/home/casto/.espressif/tools/openocd-esp32/v0.10.0-esp32-20191114/openocd-esp32/bin/openocd``)
+7. For the GDB server args, enter these args, modifying the paths to your project: `` -s share/openocd/scripts -f /home/casto/git/Sherbrooke/SwarmUs/esp32-boilerplate/tools/openocd/adafruit-esp.cfg -c "program_esp /home/casto/git/Sherbrooke/SwarmUs/esp32-boilerplate/cmake-build-target/esp32-boilerplate.bin 0x10000"``
+
+Debugging is also supported in VS Code. Here is an example launch and task files necessary. Some changes to properly resolve paths are needed (changes to the user and version might be required):
 launch.json
 ````json
     {
@@ -147,7 +159,7 @@ tasks.json
 }
 ````
 
-IMPORTANT: For some reason, VS Code has trouble attaching the debugger on the first launch. If this occurs, relaunch the configuration and the program should launch and break on app_main() entry.
+IMPORTANT: VS Code has trouble attaching the debugger on the first launch. If this occurs, relaunch the configuration and the program should launch and break on app_main() entry.
 
 ## Connections to ftd2232h breakout board
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ esp-idf/install.xx (extension varies from platform to platform, use sh for linux
 git clone https://github.com/SwarmUS/esp32-boilerplate
 ````
 
+To be able to open a serial port, you will need to add your user to the ``dialout`` group. Run ``sudo adduser YOUR_NAME dialout``.
 ## Build
 To be able to build for esp-32, you need to have some environment variables source. 
 You can run the following command to source the required variables:
@@ -56,10 +57,9 @@ To build for esp or host, do the following commands. Supplying the to cmake will
 ````
 mkdir build
 cd build
-cmake .. <-DCMAKE_TOOLCHAIN_FILE=../cmake/esp-idf/toolchain-esp32.cmake -DTARGET=esp32>
+cmake .. -DCMAKE_BUILD_TYPE=Debug <-DCMAKE_TOOLCHAIN_FILE=../cmake/esp-idf/toolchain-esp32.cmake -DTARGET=esp32>
 make
 ````
-
 
 For CLion users, since you need to source a script before running the cmake from clion, you just need to source the script before launching clion from a terminal.
 Simply run:
@@ -77,6 +77,9 @@ The esp32 target could be changed in the future to use openocd.
 The project includes a target called ``openocd-flash`` that will flash the program over JTAG with the adafruit ftd2232h breakout board. For other adapters, other .cfg might need to be supplied. 
 
 #### Debugging
+
+The xtensa debugger has a depency on libpython2.7. You can install it using your package manager.
+
 To debug using CLion, you can create a run configuration using the Embedded Gdb Server template. Follow these steps to create this configuration:
 1. Create a new configuration using Embedded GDB Server Template
 2. Set the executable to the .elf file of the project

--- a/tools/openocd/adafruit-esp.cfg
+++ b/tools/openocd/adafruit-esp.cfg
@@ -8,6 +8,6 @@ set ESP32_RTOS none
 # interface 1 is the uart
 ftdi_channel 0
 reset_config none
-adapter_khz 1000
+adapter_khz 20000
 
 source [find target/esp32.cfg]

--- a/tools/openocd/adafruit-esp.cfg
+++ b/tools/openocd/adafruit-esp.cfg
@@ -1,0 +1,13 @@
+
+interface ftdi
+ftdi_vid_pid 0x0403 0x6014
+ftdi_layout_init 0x0008 0xf00b
+ftdi_tdo_sample_edge falling
+set ESP32_RTOS none
+
+# interface 1 is the uart
+ftdi_channel 0
+reset_config none
+adapter_khz 1000
+
+source [find target/esp32.cfg]


### PR DESCRIPTION
Added a config file for openocd. Flashing via JTAG works, debugging works with VS Code. An example launch and task file has been provided in readme.